### PR TITLE
Changes

### DIFF
--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Armor.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Armor.xml
@@ -65,6 +65,14 @@
 			</stuffCategories>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/graphicData</xpath>
+		<value>
+			<ignoreThingDrawColor>true</ignoreThingDrawColor>
+		</value>
+	</Operation>
+	
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_MAU_AML"]/recipeMaker/unfinishedThingDef</xpath>
@@ -189,6 +197,13 @@
 			<stuffCategories>
 				<li>Steeled</li>
 			</stuffCategories>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_MAU_MAH"]/graphicData</xpath>
+		<value>
+			<ignoreThingDrawColor>true</ignoreThingDrawColor>
 		</value>
 	</Operation>
 

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Head.xml
@@ -5,7 +5,7 @@
 
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[
-		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_Mega" or 
 		defName="Apparel_MAU_2Mega"
 		]/statBases</xpath>
 		<value>
@@ -38,7 +38,7 @@
 	
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
-		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_Mega" or 
 		defName="Apparel_MAU_2Mega"
 		]/statBases/ArmorRating_Sharp</xpath>
 		<value>
@@ -48,7 +48,7 @@
 	
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[
-		defName="Apparel_MAU_2Mega" or 
+		defName="Apparel_MAU_Mega" or 
 		defName="Apparel_MAU_2Mega"
 		]/statBases/ArmorRating_Blunt</xpath>
 		<value>
@@ -83,15 +83,6 @@
 		<xpath>Defs/ThingDef[defName="Apparel_MAU_Mask"]/equippedStatOffsets</xpath>
 		<value>
 			<SmokeSensitivity>-1</SmokeSensitivity>
-		</value>
-	</Operation>
-	
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[
-		defName="Apparel_MAU_Mask" 
-		]/apparel/layers</xpath>
-		<value>
-			<li>StrappedHead</li>
 		</value>
 	</Operation>
 	
@@ -164,6 +155,18 @@
 			<li Class="CombatExtended.ApparelDefExtension">
 				<isRadioPack>true</isRadioPack>
 			</li>
+		</value>
+	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[
+			defName="Apparel_MAU_Rimk" or 
+			defName="Apparel_MAU_MortarRimk" or 
+			defName="Apparel_MAU_MKNTRimk" or 
+			defName="Apparel_MAU_Nekomimi" or  
+			defName="Apparel_MAU_Helmet"]/apparel/layers</xpath>
+		<value>
+			<li>StrappedHead</li>
 		</value>
 	</Operation>
 	

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_HeavyTurretpack.xml
@@ -70,6 +70,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_MAU_2TacticalTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
+			<NightVisionEfficiency>0.5</NightVisionEfficiency>
 		</value>
 	</Operation>
 

--- a/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
+++ b/ModPatches/Misstall's Armor and Uniforms/Patches/Misstall's Armor and Uniforms/Misstall_Turretpack.xml
@@ -72,6 +72,7 @@
 		<xpath>Defs/ThingDef[defName="Turret_MAU_TacticalTurret"]/statBases</xpath>
 		<value>
 			<AimingAccuracy>0.25</AimingAccuracy>
+			<NightVisionEfficiency>0.5</NightVisionEfficiency>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
NV added to turrets.
<ignoreThingDrawColor>true</ignoreThingDrawColor> added to vests Fixed missing def to patch.
Swapped head layering around, as doubling up on gas masks is less intrusive/gamebreaking than doubling up on mech count/NV/Gunlink buffs.

## Additions

Describe new functionality added by your code, e.g.
- Tribal smoke bombs
- New tribal smoke bomb sprite
- Tribal smoke bomb recipes at smithing bench and crafting spot using prometheum

## Changes

Describe adjustments to existing features made in this merge, e.g.
- Increased regular smoke bomb radius

## References

Links to the associated issues or other related pull requests, e.g.
- Closes #[ISSUE_NUMBER]
- Contributes towards #[ISSUE_NUMBER]

## Reasoning

Why did you choose to implement things this way, e.g.
- Tribals need ways to close distance with pirate raiders
- Smoke bombs allow this while enhancing combat micro
- Thematically appropriate as we already allow tribal prometheum handling
- Easy to implement
- Buffed regular smoke grenades as they are rarely utilized and to justify additional investment

## Alternatives

Describe alternative implementations you have considered, e.g.
- Tribal catapult that launches melee animals into siege camps:
  - Additional use for animals
  - Anachronistic
  - Breaks realism theme

## Testing

Check tests you have performed:
- [ ] Compiles without warnings
- [ ] Game runs without errors
- [ ] (For compatibility patches) ...with and without patched mod loaded
- [ ] Playtested a colony (specify how long)
